### PR TITLE
Updated extract-chunks.js getNames to handle circular dependencies

### DIFF
--- a/src/lib/extract-chunks.js
+++ b/src/lib/extract-chunks.js
@@ -41,11 +41,11 @@ function getNames (groups, processed = new Set()) {
         names.push(group.options.name)
       }
     } else if(!processed.has(group)) {
-      processed.add(group);
+      processed.add(group)
       names.push(...getNames(group.parentsIterable, processed))
     }
   }
-  return names;
+  return names
 }
 
 function extractChunks ({ compilation, optionsInclude }) {

--- a/src/lib/extract-chunks.js
+++ b/src/lib/extract-chunks.js
@@ -31,8 +31,7 @@ function getChunkEntryNames (chunk) {
   }
 }
 
-const processedGroups = new Set();
-function getNames (groups) {
+function getNames (groups, processed = new Set()) {
   const Entrypoint = require('webpack/lib/Entrypoint')
   const names = []
   for (const group of groups) {
@@ -41,13 +40,12 @@ function getNames (groups) {
       if (group.options.name) {
         names.push(group.options.name)
       }
-    }
-    else if (!processedGroups.has(group)) {
-      processedGroups.add(group);
-      names.push(...getNames(group.parentsIterable));
+    } else if(!processed.has(group)) {
+      processed.add(group);
+      names.push(...getNames(group.parentsIterable, processed))
     }
   }
-  return names
+  return names;
 }
 
 function extractChunks ({ compilation, optionsInclude }) {

--- a/src/lib/extract-chunks.js
+++ b/src/lib/extract-chunks.js
@@ -31,6 +31,7 @@ function getChunkEntryNames (chunk) {
   }
 }
 
+const processedGroups = new Set();
 function getNames (groups) {
   const Entrypoint = require('webpack/lib/Entrypoint')
   const names = []
@@ -40,8 +41,10 @@ function getNames (groups) {
       if (group.options.name) {
         names.push(group.options.name)
       }
-    } else {
-      names.push(...getNames(group.parentsIterable))
+    }
+    else if (!processedGroups.has(group)) {
+      processedGroups.add(group);
+      names.push(...getNames(group.parentsIterable));
     }
   }
   return names


### PR DESCRIPTION
[Suggested fix](https://github.com/vuejs/vue-cli/issues/2463#issuecomment-422236514) by [wuservices](https://github.com/wuservices) to better handle circular dependencies causing the error:

```
ERROR  Failed to compile with 1 errors                                                                                                                                                                                                                                                              15:20:37

  RangeError: Maximum call stack size exceeded

  - Array.join

  - loader.js:228 Function.Module._findPath
    internal/modules/cjs/loader.js:228:56

  - loader.js:591 Function.Module._resolveFilename
    internal/modules/cjs/loader.js:591:25

  - loader.js:520 Function.Module._load
    internal/modules/cjs/loader.js:520:25

  - loader.js:650 Module.require
    internal/modules/cjs/loader.js:650:17

  - helpers.js:20 require
    internal/modules/cjs/helpers.js:20:18

  - extract-chunks.js:35 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:35:22

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21

  - extract-chunks.js:44 getNames
    [vue-cli3]/[@vue]/preload-webpack-plugin/src/lib/extract-chunks.js:44:21
```