### PR TITLE
Don't use public path when determining the as value as it causes issues when parsing the path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ class PreloadPlugin {
       // then we need to set the 'as' attribute correctly.
       if (options.rel === 'preload') {
         attributes.as = determineAsValue({
-          href,
+          href: file,
           optionsAs: options.as
         })
 


### PR DESCRIPTION
Fixes https://github.com/vuejs/vue-cli/issues/5672

Since the determineAsValue parses the href using `new URL(href, 'https://example.com').pathname` and the href passed to it contains the publicPath option of vue cli, if this option contains special characters (Mainly '?') the url will not be parsed correctly and it will always use the default as value ('script')