### PR TITLE
lower html-webpack-plugin 4 peer dependency version 4.5.1 -> 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^5.20.0"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^5.0.0 || ^4.5.1",
+    "html-webpack-plugin": "^5.0.0 || ^4.5.0",
     "webpack": "^5.20.0 || ^4.1.0"
   }
 }


### PR DESCRIPTION
Npm 7+ doesn't allow installing preload-webpack-plugin alongside html-webpack-plugin 4.5.0 without runnig --legacy-peer-deps, although it works fine with 4.5.0 version.
I use Create React App v.4.0.3 and have no control over html-webpack-plugin version, but i wanted to customize CRA config without ejecting and i believe many people would potentially want to do the same.