### PR TITLE
Gracefully handle missing directory separators in publicPath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const defaultOptions = require('./lib/default-options')
 const determineAsValue = require('./lib/determine-as-value')
 const doesChunkBelongToHTML = require('./lib/does-chunk-belong-to-html')
 const extractChunks = require('./lib/extract-chunks')
+const joinPaths = require('./lib/join-paths')
 
 class PreloadPlugin {
   constructor (options) {
@@ -76,7 +77,7 @@ class PreloadPlugin {
         ? webpackPublicPath : ''
       : webpackPublicPath || ''
     for (const file of sortedFilteredFiles) {
-      const href = `${publicPath}${file}`
+      const href = joinPaths(publicPath, file)
 
       const attributes = {
         href,

--- a/src/lib/join-paths.js
+++ b/src/lib/join-paths.js
@@ -1,0 +1,17 @@
+
+function joinPaths (...segments) {
+  let joined = segments
+    .map((segment) => segment.replace(/^\/|\/$/g, ''))
+    .filter(Boolean)
+    .join('/')
+
+  const first = segments[0]
+  const last = segments[segments.length - 1]
+
+  if (first[0] === '/') joined = `/${joined}`
+  if (last[last.length - 1] === '/') joined = `${joined}/`
+
+  return joined
+}
+
+module.exports = joinPaths


### PR DESCRIPTION
Ran into an issue where if the publicPath does not have a trailing slash, the output result gets concatenated wrong (adding a trailing slash broke other plugins). This PR addresses that scenario.